### PR TITLE
SEPSIS Monthly Update - April

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,11 +1,13 @@
-Medium Update - Pills & Bottles Overhaul
+Medium Update - Water Purity & Tourniquets
 
-- Fixed a bug where contaminants did not reset upon removal
-- Changed default liquid values so glass bottles can also hold pills
-- Changed dialogue and scripts for all pills and liquids to "Consume"
-- Added plastic pill bottle which defaults with Acetaminophen
-- Acetaminophen has the same effect as morphine for 30 seconds
-- Consumption function now dynamically reduces liquids below the 25 mL threshold
-- Resprited the glass bottle
-- Resprited the blister pack for improved dynamic liquid transfer
-- Glass and plastic bottles can now hold both liquids and pills
+- Added tourniquet
+   - Level 4 bleed healing speed
+   - Level 1 wound healing speed
+- Added water cleanliness
+- Added charcoal tablets
+   - Add 10% water purity
+- Water purity now displays in-hand and in-inventory modifiers
+- Blister pack pills can now be applied to items
+   - Only one that can is the charcoal tablets which clean water
+- Applied items for limbs now only display in the first health tab
+- Drinking water with higher impurity (less cleanliness) has higher chance of producing nausea condition

--- a/README.txt
+++ b/README.txt
@@ -1,15 +1,17 @@
-Significant Update - Bone Medical Items
+Significant Update - Organ Medical Items, Clothing Redux, Misc.
 
-- Added splint item (fracture heal +2)
-- Added bone item application
-- Fracture items can only be applied to limbs
-- Added bone item application for each bone (ulna and radius have separate individuals splints, etc.)
-- Added dynamic healing for fractures that is now affected by any applied items
-- Fixed bug with previous bone-application where non-applied bones would cause a crash
-- Applicable fracture-based medical items now heal fractures faster
-- Added brace (+1 fracture heal)
-- Added dynamic applied-item visuals for the splint and brace
-- Bones can only hold one applied item now (fixes disappearing items)
-- All body parts passively heal 0.1% per second when not under any damage
-- Condensed script for determining the max condition of a bone
-- Bones now lower 15% max condition for every level of fracture (previously 10%)
+- Organ wounds can now be flushed out with liquids
+- Added new dynamic visual implementation for certain items
+- Bandages can now be tightly rolled/unrolled with left click
+- Can now place rolled up bandages in organ wounds
+- Temporarily removed dynamic clothing-condition sprites
+- Cleanliness now no longer displays on non-applicable items in-inventory on-hover
+- Adhesives now correctly color their remaining uses in-inventory on-hover
+- Resprited both boots, gloves, helmet, and the coat
+- Clothing items that have carrying capacity >0 can now be folded
+- Clothing items that have carrying capacity >0 cannot be put in other clothing items unless they are folded
+- Can fold clothing only when it is empty
+- Fixed in-hand sizing for shirt, boots, coat, backpack, and misc.
+- If the player tries to place an unfolded clothing item in another, a message will pop up
+- Moved strapped stick on-grid
+- Fixed dot-counter so it now displays mineral facts for foods in-inventory on-hover

--- a/README.txt
+++ b/README.txt
@@ -1,17 +1,11 @@
-Medium Update - Radiation Medical Items
+Medium Update - Pills & Bottles Overhaul
 
-- Treatment now goes down over time
-- Added iodine solution
-   - Drinking results in level 1 treatment of all body parts and -1 radiation to thyroid but 50% chance of nausea
-   - Applying to items (gauze rolls) adds disinfection level 2 and -1 radiation
-- Fixed probiotic and immuno+ so they can only treat up to level 1
-- The glass bottle now has sprites for each contained liquid
-- Changed name of disinfectant bottle to 'glass bottle'
-- Changed the color of disinfectant in the water bottle for more distinction
-- There is now an empty IV bag sprite
-- IV Bag resets when empty
-- Immuno+ and Probiotic Tablets now affect ALL body parts (not random)
-- Added iodine pills
-   - Same effects as immuno+ in addition to -1 radiation in all body parts
-- Fixed bug where crash would occur when radiated wounds go back to normal levels
-- Player can no directly splash isopropanol and iodine onto open wounds
+- Fixed a bug where contaminants did not reset upon removal
+- Changed default liquid values so glass bottles can also hold pills
+- Changed dialogue and scripts for all pills and liquids to "Consume"
+- Added plastic pill bottle which defaults with Acetaminophen
+- Acetaminophen has the same effect as morphine for 30 seconds
+- Consumption function now dynamically reduces liquids below the 25 mL threshold
+- Resprited the glass bottle
+- Resprited the blister pack for improved dynamic liquid transfer
+- Glass and plastic bottles can now hold both liquids and pills

--- a/README.txt
+++ b/README.txt
@@ -1,9 +1,15 @@
-Medium Update - Stitching System
+Significant Update - Bone Medical Items
 
-- Changed bleed remedy of tourniquet to 8 (from 4)
-- Added needle and thread (2 separate items)
-- Body parts can now be stitched with thread and needle (level 8 wound and bleed remedy)
-- Fixed bug where you could stack any items in-hand
-- Fixed a bug where the health could be closed while holding item with mouse, making inventory unable to open when closed
-- Stitching automatically removes once wound is completely healed, but cannot be removed during the process
-- When stitching, (3*open_wound_amount) yards of thread is used
+- Added splint item (fracture heal +2)
+- Added bone item application
+- Fracture items can only be applied to limbs
+- Added bone item application for each bone (ulna and radius have separate individuals splints, etc.)
+- Added dynamic healing for fractures that is now affected by any applied items
+- Fixed bug with previous bone-application where non-applied bones would cause a crash
+- Applicable fracture-based medical items now heal fractures faster
+- Added brace (+1 fracture heal)
+- Added dynamic applied-item visuals for the splint and brace
+- Bones can only hold one applied item now (fixes disappearing items)
+- All body parts passively heal 0.1% per second when not under any damage
+- Condensed script for determining the max condition of a bone
+- Bones now lower 15% max condition for every level of fracture (previously 10%)

--- a/README.txt
+++ b/README.txt
@@ -1,13 +1,9 @@
-Medium Update - Water Purity & Tourniquets
+Medium Update - Stitching System
 
-- Added tourniquet
-   - Level 4 bleed healing speed
-   - Level 1 wound healing speed
-- Added water cleanliness
-- Added charcoal tablets
-   - Add 10% water purity
-- Water purity now displays in-hand and in-inventory modifiers
-- Blister pack pills can now be applied to items
-   - Only one that can is the charcoal tablets which clean water
-- Applied items for limbs now only display in the first health tab
-- Drinking water with higher impurity (less cleanliness) has higher chance of producing nausea condition
+- Changed bleed remedy of tourniquet to 8 (from 4)
+- Added needle and thread (2 separate items)
+- Body parts can now be stitched with thread and needle (level 8 wound and bleed remedy)
+- Fixed bug where you could stack any items in-hand
+- Fixed a bug where the health could be closed while holding item with mouse, making inventory unable to open when closed
+- Stitching automatically removes once wound is completely healed, but cannot be removed during the process
+- When stitching, (3*open_wound_amount) yards of thread is used

--- a/README.txt
+++ b/README.txt
@@ -1,15 +1,17 @@
-Medium Update - Pill-Based Medical Items
+Medium Update - Radiation Medical Items
 
-- Fixed bug where water would not wash out the correctly sized contaminant
-- Added medical pliers
-   - Can extract medium contaminants from wounds
-- Dynamic liquid condition coloring in-inventory on-hover
-- Added Immuno+
-   - Adds one treatment to random body parts/organs
-- Added probiotic tablets
-   - Adds one treatment to random body parts/organs
-   - Increases digestion factor by 0.2 per pill
-- All pills increase tiredness by 5%
-- Removed screenshake at low consciousness
-- Added cephazolin (antibiotic) drips
-   - All body parts and organs are 3+ treated
+- Treatment now goes down over time
+- Added iodine solution
+   - Drinking results in level 1 treatment of all body parts and -1 radiation to thyroid but 50% chance of nausea
+   - Applying to items (gauze rolls) adds disinfection level 2 and -1 radiation
+- Fixed probiotic and immuno+ so they can only treat up to level 1
+- The glass bottle now has sprites for each contained liquid
+- Changed name of disinfectant bottle to 'glass bottle'
+- Changed the color of disinfectant in the water bottle for more distinction
+- There is now an empty IV bag sprite
+- IV Bag resets when empty
+- Immuno+ and Probiotic Tablets now affect ALL body parts (not random)
+- Added iodine pills
+   - Same effects as immuno+ in addition to -1 radiation in all body parts
+- Fixed bug where crash would occur when radiated wounds go back to normal levels
+- Player can no directly splash isopropanol and iodine onto open wounds

--- a/README.txt
+++ b/README.txt
@@ -1,27 +1,19 @@
-Significant Update - Medical Items: Part 7
+Medium Update - Adrenaline-Based Medical Items
 
-- Liquids can be used to wash SMALL contaminants out of wounds
-   - Liquids wash at 25 mL per splash
-- Contaminant now resets when the contaminant piece count falls at or below 0
-- Changed water bottle so it defaults as empty
--  Item close-ups and descriptions can no longer be visible in the health menu on-hover
-- Changed the Disinfectant to "Disinfectant Bottle"
-- Changed the Clotting Powder to "Bottle of Clotting Powder"
-- Slightly changed sizing of hover-item dialogue
-- Added sound when washing out SMALL contaminants with liquid
-- Water cannot be drank again until the sound finishes
-- Fixed water bottle to show dynamic liquid image
-- Water bottle can now dynamically show it holding disinfectant, clotting powder, and blood
-- IV Bags, Alcohol Bottles, and Clotting Powder bottles now can dynamically hold any liquids
-- Fixed reset bug which caused a crash when trying to apply disinfected items
-- Fixed bug where treatment would not stay after wounds healed
-- Water can be applied to disinfectable items to add treatment level 1
-- All liquid containers can dynamically apply liquids to applicable items
-- Disinfect and clot functions combined into one function
-- Drinking isopropanol (disinfectant) poisons and kills you
-- Drinking clotting powder chokes and kills you
-- Player can shoot themselves with any gun (hold left control with gun in hand and left click)
-- Fixed bug where using some pre-loaded extended and clear VZ58 Magazines would cause a crash
-- Changed default sleep and recovery speeds
-- Fixed bug where game would crash when using SAL-COAG IV in right hand
-- Renamed pressure injector to "SAL-COAG IV Injector"
+- Added adreno-injection
+   - Increases adrenaline by 100 ng
+- Added dedreno-injection
+   - Decreases adrenaline by 50 ng and adrenaline deficit by 25 ng
+   - Reduces heart rate by 25 BPM
+- Mouse shake no longer occurs holding shift with no weapons in-hand
+- Sprinting increases the heart rate rapidly
+- Cannot sprint if your heartbeat exceed 200 BPM
+- Adrenaline now dynamically affects heartrate instead of immediately (rise and fall gradually)
+- Aim shaking also increases with heartrate
+- Fixed bug where player could aim even after dropping the weapon
+- Added morphine injection
+    - Effects last 1 minute
+    - Hearrate is stable at 60 BPM
+    - Hand shaking is 0
+    - Outside sources do not affect heartrate or adrenaline
+- Added morphine drips

--- a/README.txt
+++ b/README.txt
@@ -1,19 +1,15 @@
-Medium Update - Adrenaline-Based Medical Items
+Medium Update - Pill-Based Medical Items
 
-- Added adreno-injection
-   - Increases adrenaline by 100 ng
-- Added dedreno-injection
-   - Decreases adrenaline by 50 ng and adrenaline deficit by 25 ng
-   - Reduces heart rate by 25 BPM
-- Mouse shake no longer occurs holding shift with no weapons in-hand
-- Sprinting increases the heart rate rapidly
-- Cannot sprint if your heartbeat exceed 200 BPM
-- Adrenaline now dynamically affects heartrate instead of immediately (rise and fall gradually)
-- Aim shaking also increases with heartrate
-- Fixed bug where player could aim even after dropping the weapon
-- Added morphine injection
-    - Effects last 1 minute
-    - Hearrate is stable at 60 BPM
-    - Hand shaking is 0
-    - Outside sources do not affect heartrate or adrenaline
-- Added morphine drips
+- Fixed bug where water would not wash out the correctly sized contaminant
+- Added medical pliers
+   - Can extract medium contaminants from wounds
+- Dynamic liquid condition coloring in-inventory on-hover
+- Added Immuno+
+   - Adds one treatment to random body parts/organs
+- Added probiotic tablets
+   - Adds one treatment to random body parts/organs
+   - Increases digestion factor by 0.2 per pill
+- All pills increase tiredness by 5%
+- Removed screenshake at low consciousness
+- Added cephazolin (antibiotic) drips
+   - All body parts and organs are 3+ treated


### PR DESCRIPTION
- Added adreno-injection
   - Increases adrenaline by 100 ng
- Added dedreno-injection
   - Decreases adrenaline by 50 ng and adrenaline deficit by 25 ng
   - Reduces heart rate by 25 BPM
- Mouse shake no longer occurs holding shift with no weapons in-hand
- Sprinting increases the heart rate rapidly
- Cannot sprint if your heartbeat exceed 200 BPM
- Adrenaline now dynamically affects heartrate instead of immediately (rise and fall gradually)
- Aim shaking also increases with heartrate
- Fixed bug where player could aim even after dropping the weapon
- Added morphine injection
    - Effects last 1 minute
    - Heartrate is stable at 60 BPM
    - Hand shaking is 0
    - Outside sources do not affect heartrate or adrenaline
- Added morphine drips

- Fixed bug where water would not wash out the correctly sized contaminant
- Added medical pliers
   - Can extract medium contaminants from wounds
- Dynamic liquid condition coloring in-inventory on-hover
- Added Immuno+
   - Adds one treatment to random body parts/organs
- Added probiotic tablets
   - Adds one treatment to random body parts/organs
   - Increases digestion factor by 0.2 per pill
- All pills increase tiredness by 5%
- Removed screenshake at low consciousness
- Added cephazolin (antibiotic) drips
   - All body parts and organs are 3+ treated

- Treatment now goes down over time
- Added iodine solution
   - Drinking results in level 1 treatment of all body parts and -1 radiation to thyroid but 50% chance of nausea
   - Applying to items (gauze rolls) adds disinfection level 2 and -1 radiation
- Fixed probiotic and immuno+ so they can only treat up to level 1
- The glass bottle now has sprites for each contained liquid
- Changed name of disinfectant bottle to 'glass bottle'
- Changed the color of disinfectant in the water bottle for more distinction
- There is now an empty IV bag sprite
- IV Bag resets when empty
- Immuno+ and Probiotic Tablets now affect ALL body parts (not random)
- Added iodine pills
   - Same effects as immuno+ in addition to -1 radiation in all body parts
- Fixed bug where crash would occur when radiated wounds go back to normal levels
- Player can no directly splash isopropanol and iodine onto open wounds

- Fixed a bug where contaminants did not reset upon removal
- Changed default liquid values so glass bottles can also hold pills
- Changed dialogue and scripts for all pills and liquids to "Consume"
- Added plastic pill bottle which defaults with Acetaminophen
- Acetaminophen has the same effect as morphine for 30 seconds
- Consumption function now dynamically reduces liquids below the 25 mL threshold
- Resprited the glass bottle
- Resprited the blister pack for improved dynamic liquid transfer
- Glass and plastic bottles can now hold both liquids and pills

- Added tourniquet
   - Level 4 bleed healing speed
   - Level 1 wound healing speed
- Added water cleanliness
- Added charcoal tablets
   - Add 10% water purity
- Water purity now displays in-hand and in-inventory modifiers
- Blister pack pills can now be applied to items
   - Only one that can is the charcoal tablets which clean water
- Applied items for limbs now only display in the first health tab
- Drinking water with higher impurity (less cleanliness) has higher chance of producing nausea condition

- Changed bleed remedy of tourniquet to 8 (from 4)
- Added needle and thread (2 separate items)
- Body parts can now be stitched with thread and needle (level 8 wound and bleed remedy)
- Fixed bug where you could stack any items in-hand
- Fixed a bug where the health could be closed while holding item with mouse, making inventory unable to open when closed
- Stitching automatically removes once wound is completely healed, but cannot be removed during the process
- When stitching, (3*open_wound_amount) yards of thread is used

- Added splint item (fracture heal +2)
- Added bone item application
- Fracture items can only be applied to limbs
- Added bone item application for each bone (ulna and radius have separate individuals splints, etc.)
- Added dynamic healing for fractures that is now affected by any applied items
- Fixed bug with previous bone-application where non-applied bones would cause a crash
- Applicable fracture-based medical items now heal fractures faster
- Added brace (+1 fracture heal)
- Added dynamic applied-item visuals for the splint and brace
- Bones can only hold one applied item now (fixes disappearing items)
- All body parts passively heal 0.1% per second when not under any damage
- Condensed script for determining the max condition of a bone
- Bones now lower 15% max condition for every level of fracture (previously 10%)

- Organ wounds can now be flushed out with liquids
- Added new dynamic visual implementation for certain items
- Bandages can now be tightly rolled/unrolled with left click
- Can now place rolled up bandages in organ wounds
- Temporarily removed dynamic clothing-condition sprites
- Cleanliness now no longer displays on non-applicable items in-inventory on-hover
- Adhesives now correctly color their remaining uses in-inventory on-hover
- Resprited both boots, gloves, helmet, and the coat
- Clothing items that have carrying capacity >0 can now be folded
- Clothing items that have carrying capacity >0 cannot be put in other clothing items unless they are folded
- Can fold clothing only when it is empty
- Fixed in-hand sizing for shirt, boots, coat, backpack, and misc.
- If the player tries to place an unfolded clothing item in another, a message will pop up
- Moved strapped stick on-grid
- Fixed dot-counter so it now displays mineral facts for foods in-inventory on-hover